### PR TITLE
FIX: double / on sourceDirectory default value

### DIFF
--- a/src/main/java/pl/allegro/tdr/gruntmaven/BaseMavenGruntMojo.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/BaseMavenGruntMojo.java
@@ -43,7 +43,7 @@ public abstract class BaseMavenGruntMojo extends AbstractMojo {
     /**
      * Path to dir, where jsSourceDir is located, defaults to src/main/webapp.
      */
-    @Parameter(property = "sourceDirectory", defaultValue = "src/main/webapp/")
+    @Parameter(property = "sourceDirectory", defaultValue = "src/main/webapp")
     protected String sourceDirectory;
 
     /**


### PR DESCRIPTION
It causes the grunt-maven.json filesToWatch to be like src/main/webapp/static//**.
