### PR TITLE
Maven 2 compatibility issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
             <version>3.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
+
         <!-- mojos -->
         <dependency>
             <groupId>org.twdata.maven</groupId>

--- a/src/main/java/pl/allegro/tdr/gruntmaven/archive/TarUtil.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/archive/TarUtil.java
@@ -16,10 +16,11 @@
 package pl.allegro.tdr.gruntmaven.archive;
 
 import java.io.*;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.archiver.tar.TarEntry;
 import org.codehaus.plexus.archiver.tar.TarInputStream;
-import org.codehaus.plexus.util.IOUtil;
 
 /**
  *
@@ -47,7 +48,7 @@ public final class TarUtil {
                 } else {
                     logger.debug("creating file at: " + outputFile.getCanonicalPath());
                     output = new FileOutputStream(outputFile);
-                    IOUtil.copy(tarInput, output);
+                    IOUtils.copy(tarInput, output);
                     output.flush();
                     output.close();
                 }
@@ -57,8 +58,8 @@ public final class TarUtil {
         } catch (IOException exception) {
             throw new IllegalStateException(exception);
         } finally {
-            IOUtil.close(tarInput);
-            IOUtil.close(output);
+            IOUtils.closeQuietly(tarInput);
+            IOUtils.closeQuietly(output);
         }
     }
 }

--- a/src/main/java/pl/allegro/tdr/gruntmaven/resources/Resource.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/resources/Resource.java
@@ -22,11 +22,10 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.logging.Log;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.util.io.InputStreamFacade;
-import org.codehaus.plexus.util.io.RawInputStreamFacade;
 
 /**
  *
@@ -68,7 +67,7 @@ public class Resource {
 
             File targetFile = new File(targetPath);
             if (!targetFile.exists() || overwrite) {
-                FileUtils.copyStreamToFile(contentAsInputStream(contents), targetFile);
+                FileUtils.copyInputStreamToFile(contentAsInputStream(contents), targetFile);
             } else {
                 logger.debug("Not overwriting file " + targetPath);
             }
@@ -77,17 +76,15 @@ public class Resource {
         }
     }
 
-    private InputStreamFacade contentAsInputStream(String content) {
-        return new RawInputStreamFacade(
-                new ByteArrayInputStream(content.getBytes())
-        );
+    private InputStream contentAsInputStream(String content) {
+        return new ByteArrayInputStream(content.getBytes());
     }
 
     private String read() throws IOException {
         InputStream stream = Resource.class.getResourceAsStream(resourceName);
         StringWriter contentsWriter = new StringWriter();
 
-        IOUtil.copy(stream, contentsWriter);
+        IOUtils.copy(stream, contentsWriter);
         return contentsWriter.toString();
     }
 


### PR DESCRIPTION
Hi, I think there's a compatibility problem with Maven 2 :

```
$ mvn --version
Apache Maven 2.2.1 (r801777; 2009-08-06 21:16:01+0200)
Java version: 1.7.0_65
Java home: /usr/lib/jvm/java-7-openjdk/jre
Default locale: fr_FR, platform encoding: UTF-8
OS name: "linux" version: "3.14.14-1-manjaro" arch: "amd64" Family: "unix"
```

```
$ mvn pl.allegro:grunt-maven-plugin:1.4.1:create-resources
[FATAL ERROR] pl.allegro.tdr.gruntmaven.CreateResourcesMojo#execute() caused a linkage error (java.lang.NoClassDefFoundError) and may be out-of-date. Check the realms:
[FATAL ERROR] Plugin realm = app0.child-container[pl.allegro:grunt-maven-plugin:1.4.1]
urls[0] = file:/home/pgmillon/.m2/repository/pl/allegro/grunt-maven-plugin/1.4.1/grunt-maven-plugin-1.4.1.jar
urls[1] = file:/home/pgmillon/.m2/repository/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
urls[2] = file:/home/pgmillon/.m2/repository/org/apache/maven/plugin-tools/maven-plugin-tools-annotations/3.2/maven-plugin-tools-annotations-3.2.jar
urls[3] = file:/home/pgmillon/.m2/repository/org/apache/maven/plugin-tools/maven-plugin-tools-api/3.2/maven-plugin-tools-api-3.2.jar
urls[4] = file:/home/pgmillon/.m2/repository/org/apache/maven/plugin-tools/maven-plugin-annotations/3.2/maven-plugin-annotations-3.2.jar
urls[5] = file:/home/pgmillon/.m2/repository/asm/asm/3.3.1/asm-3.3.1.jar
urls[6] = file:/home/pgmillon/.m2/repository/asm/asm-commons/3.3.1/asm-commons-3.3.1.jar
urls[7] = file:/home/pgmillon/.m2/repository/asm/asm-tree/3.3.1/asm-tree-3.3.1.jar
urls[8] = file:/home/pgmillon/.m2/repository/org/codehaus/plexus/plexus-archiver/2.1.1/plexus-archiver-2.1.1.jar
urls[9] = file:/home/pgmillon/.m2/repository/org/codehaus/plexus/plexus-io/2.0.3/plexus-io-2.0.3.jar
urls[10] = file:/home/pgmillon/.m2/repository/com/thoughtworks/qdox/qdox/1.12.1/qdox-1.12.1.jar
urls[11] = file:/home/pgmillon/.m2/repository/org/twdata/maven/mojo-executor/1.5.2/mojo-executor-1.5.2.jar
urls[12] = file:/home/pgmillon/.m2/repository/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar
urls[13] = file:/home/pgmillon/.m2/repository/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar
urls[14] = file:/home/pgmillon/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar
urls[15] = file:/home/pgmillon/.m2/repository/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.jar
[FATAL ERROR] Container realm = plexus.core
urls[0] = file:/home/pgmillon/Applications/apache-maven-2.2.1/lib/maven-2.2.1-uber.jar
urls[1] = file:/home/pgmillon/.m2/repository/fr/kiabi/bekom/rules/code-checking-rules/1.0.0/code-checking-rules-1.0.0.jar
[INFO] ------------------------------------------------------------------------
[ERROR] FATAL ERROR
[INFO] ------------------------------------------------------------------------
[INFO] org/codehaus/plexus/util/io/InputStreamFacade
org.codehaus.plexus.util.io.InputStreamFacade
[INFO] ------------------------------------------------------------------------
[INFO] Trace
java.lang.NoClassDefFoundError: org/codehaus/plexus/util/io/InputStreamFacade
    at pl.allegro.tdr.gruntmaven.CreateResourcesMojo.createInnerPropertiesResource(CreateResourcesMojo.java:149)
    at pl.allegro.tdr.gruntmaven.CreateResourcesMojo.executeInternal(CreateResourcesMojo.java:97)
    at pl.allegro.tdr.gruntmaven.BaseMavenGruntMojo.execute(BaseMavenGruntMojo.java:93)
    at org.apache.maven.plugin.DefaultPluginManager.executeMojo(DefaultPluginManager.java:490)
    at org.apache.maven.lifecycle.DefaultLifecycleExecutor.executeGoals(DefaultLifecycleExecutor.java:694)
    at org.apache.maven.lifecycle.DefaultLifecycleExecutor.executeStandaloneGoal(DefaultLifecycleExecutor.java:569)
    at org.apache.maven.lifecycle.DefaultLifecycleExecutor.executeGoal(DefaultLifecycleExecutor.java:539)
    at org.apache.maven.lifecycle.DefaultLifecycleExecutor.executeGoalAndHandleFailures(DefaultLifecycleExecutor.java:387)
    at org.apache.maven.lifecycle.DefaultLifecycleExecutor.executeTaskSegments(DefaultLifecycleExecutor.java:348)
    at org.apache.maven.lifecycle.DefaultLifecycleExecutor.execute(DefaultLifecycleExecutor.java:180)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:328)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:138)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:362)
    at org.apache.maven.cli.compat.CompatibleMain.main(CompatibleMain.java:60)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.codehaus.classworlds.Launcher.launchEnhanced(Launcher.java:315)
    at org.codehaus.classworlds.Launcher.launch(Launcher.java:255)
    at org.codehaus.classworlds.Launcher.mainWithExitCode(Launcher.java:430)
    at org.codehaus.classworlds.Launcher.main(Launcher.java:375)
Caused by: java.lang.ClassNotFoundException: org.codehaus.plexus.util.io.InputStreamFacade
    at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
    at org.codehaus.classworlds.RealmClassLoader.loadClassDirect(RealmClassLoader.java:195)
    at org.codehaus.classworlds.DefaultClassRealm.loadClass(DefaultClassRealm.java:255)
    at org.codehaus.classworlds.DefaultClassRealm.loadClass(DefaultClassRealm.java:274)
    at org.codehaus.classworlds.RealmClassLoader.loadClass(RealmClassLoader.java:214)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
    ... 22 more
```
