### PR TITLE
mark all mojos as threadSafe

### DIFF
--- a/src/main/java/pl/allegro/tdr/gruntmaven/CleanResourcesMojo.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/CleanResourcesMojo.java
@@ -35,7 +35,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
  *
  * @author Adam Dubiel
  */
-@Mojo(name = "clean", defaultPhase = LifecyclePhase.CLEAN)
+@Mojo(name = "clean", defaultPhase = LifecyclePhase.CLEAN, threadSafe = true)
 public class CleanResourcesMojo extends BaseMavenGruntMojo {
 
     /**

--- a/src/main/java/pl/allegro/tdr/gruntmaven/CreateResourcesMojo.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/CreateResourcesMojo.java
@@ -31,7 +31,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
  *
  * @author Adam Dubiel
  */
-@Mojo(name = "create-resources", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Mojo(name = "create-resources", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class CreateResourcesMojo extends BaseMavenGruntMojo {
 
     private static final String INNER_PROPERTIES_RESOURCE_NAME = "grunt-maven.json";

--- a/src/main/java/pl/allegro/tdr/gruntmaven/ExecBowerMojo.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/ExecBowerMojo.java
@@ -26,7 +26,7 @@ import pl.allegro.tdr.gruntmaven.executable.Executable;
 /**
  * Executes bower install to download all dependencies declared in bower.json.
  */
-@Mojo(name = "bower", defaultPhase = LifecyclePhase.COMPILE)
+@Mojo(name = "bower", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true)
 public class ExecBowerMojo extends AbstractExecutableMojo {
 
     private static final String BOWER_INSTALL_COMMAND = "install";

--- a/src/main/java/pl/allegro/tdr/gruntmaven/ExecGruntMojo.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/ExecGruntMojo.java
@@ -27,7 +27,7 @@ import pl.allegro.tdr.gruntmaven.executable.Executable;
  *
  * @author Adam Dubiel
  */
-@Mojo(name = "grunt", defaultPhase = LifecyclePhase.COMPILE)
+@Mojo(name = "grunt", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true)
 public class ExecGruntMojo extends AbstractExecutableMojo {
 
     /**

--- a/src/main/java/pl/allegro/tdr/gruntmaven/ExecNpmMojo.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/ExecNpmMojo.java
@@ -30,7 +30,7 @@ import java.util.Map;
  *
  * @author Adam Dubiel
  */
-@Mojo(name = "npm", defaultPhase = LifecyclePhase.COMPILE)
+@Mojo(name = "npm", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true)
 public class ExecNpmMojo extends AbstractExecutableMojo {
 
     protected static final String NPM_INSTALL_COMMAND = "install";

--- a/src/main/java/pl/allegro/tdr/gruntmaven/ExecNpmOfflineMojo.java
+++ b/src/main/java/pl/allegro/tdr/gruntmaven/ExecNpmOfflineMojo.java
@@ -29,7 +29,7 @@ import pl.allegro.tdr.gruntmaven.executable.Executable;
  *
  * @author Adam Dubiel
  */
-@Mojo(name = "npm-offline", defaultPhase = LifecyclePhase.COMPILE)
+@Mojo(name = "npm-offline", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true)
 public class ExecNpmOfflineMojo extends ExecNpmMojo {
 
     private static final String NODE_MODULES_DIR_NAME = "node_modules";


### PR DESCRIPTION
Thanks for your releasing great tool. Here I have a proposal for it.

These mojos pass the [checklist for thread safety assertion](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3#ParallelbuildsinMaven3-Mojothreadsafetyassertionchecklist), so we can mark them as `threadSafe`. By this change, we can stop WARNING message in Maven build.